### PR TITLE
chatsessionのstatus設定

### DIFF
--- a/functions/src/services/chatService.ts
+++ b/functions/src/services/chatService.ts
@@ -129,9 +129,10 @@ export class ChatService {
 
     // セッション状態をチェック
     const session = await this.getSessionById(sessionId);
-    let learningRecordUpdated = false;
+    if (!session) return { aiResponse, sessionStatus: "unknown", learningRecordUpdated: false };
 
-    if (session && session.status === "draft") {
+    let learningRecordUpdated = false;
+    if (session.status === "draft") {
       const shouldPromote = await this.shouldPromoteSession(session);
       if (shouldPromote) {
         await this.promoteToActiveSession(sessionId);
@@ -141,7 +142,7 @@ export class ChatService {
 
     return {
       aiResponse,
-      sessionStatus: session?.status || "unknown",
+      sessionStatus: session.status,
       learningRecordUpdated
     };
   }


### PR DESCRIPTION
「メッセージ数4回以上、かつ3分以上経過」でactiveに昇格しなかったセッション（＝status: "draft"のまま）は、
1時間以上未更新（updatedAtが1時間以上前）になると、自動削除バッチでFirestoreから削除されます。